### PR TITLE
Update status to pending on new key upload

### DIFF
--- a/license_manager.hpp
+++ b/license_manager.hpp
@@ -5,46 +5,49 @@
 #include <sdbusplus/server/object.hpp>
 #include <sdeventplus/source/event.hpp>
 
-namespace license
-{
-namespace manager
-{
+namespace license {
+namespace manager {
 
 class LicenseMgr;
 using iface = sdbusplus::server::object::object<
     sdbusplus::com::ibm::License::server::LicenseManager>;
 
-
 /** @class Manager
  *  @brief Implementation for the license manager
  */
-class LicenseMgr : public iface
-{
-  public:
-    LicenseMgr() = delete;
-    LicenseMgr(const LicenseMgr&) = delete;
-    LicenseMgr& operator=(const LicenseMgr&) = delete;
-    LicenseMgr(LicenseMgr&&) = delete;
-    LicenseMgr& operator=(LicenseMgr&&) = delete;
-    virtual ~LicenseMgr() = default;
+class LicenseMgr : public iface {
+public:
+  LicenseMgr() = delete;
+  LicenseMgr(const LicenseMgr &) = delete;
+  LicenseMgr &operator=(const LicenseMgr &) = delete;
+  LicenseMgr(LicenseMgr &&) = delete;
+  LicenseMgr &operator=(LicenseMgr &&) = delete;
+  virtual ~LicenseMgr() = default;
 
-    /** @brief Constructor to put object onto bus at a dbus path.
-     *  @param[in] bus - Bus to attach to.
-     *  @param[in] path - Path to attach at.
-     */
-    LicenseMgr(sdbusplus::bus::bus& bus, sdeventplus::Event& event,
-              const char* path) :
-        iface(bus, path,true),
-        bus(bus), event(event), objectPath(path){
-        };
+  /** @brief Constructor to put object onto bus at a dbus path.
+   *  @param[in] bus - Bus to attach to.
+   *  @param[in] path - Path to attach at.
+   */
+  LicenseMgr(sdbusplus::bus::bus &bus, sdeventplus::Event &event,
+             const char *path)
+      : iface(bus, path, true), bus(bus), event(event), objectPath(path){};
 
-  private:
-    /** @brief sdbusplus DBus bus connection. */
-    sdbusplus::bus::bus& bus;
-    // sdevent Event handle
-    sdeventplus::Event& event;
-    /** @brief object path */
-    std::string objectPath;
+  std::string licenseString(std::string value) override {
+    // On updating new license string set licenseActivationStatus to Pending,
+    // So that status of new license activation can be updated.
+    sdbusplus::com::ibm::License::server::LicenseManager::
+        licenseActivationStatus(Status::Pending);
+    return sdbusplus::com::ibm::License::server::LicenseManager::licenseString(
+        value);
+  }
+
+private:
+  /** @brief sdbusplus DBus bus connection. */
+  sdbusplus::bus::bus &bus;
+  // sdevent Event handle
+  sdeventplus::Event &event;
+  /** @brief object path */
+  std::string objectPath;
 };
 
 } // namespace manager


### PR DESCRIPTION
This commit sets LicenseActivationStatus to Pending while updating new license key.

Tested by:

busctl  set-property com.ibm.License.Manager /com/ibm/license com.ibm.License.LicenseManager LicenseString s "test"